### PR TITLE
Apply JSDoc into `Geo2SVG`, `POIviewSelection`,`SVG2Geo`

### DIFF
--- a/SVGMapLv0.1_Class_r18module.js
+++ b/SVGMapLv0.1_Class_r18module.js
@@ -1743,8 +1743,28 @@ class SvgMap {
 
 
 // 公開メソッド
+	/**
+	 * 
+	 * @param  {number} lat
+	 * @param  {number} lng
+	 * @param  {Object} crs 
+	 * @returns {Object} { x: number, y: number } 形式のオブジェクト
+	 */
 	Geo2SVG(...params){ return (this.#matUtil.Geo2SVG(...params))};
+	/**
+	 * 
+	 * @param  {SVGElement} poi
+	 * @returns {undefined}
+	 */
 	POIviewSelection(...params){ return (this.#mapTicker.POIviewSelection(...params)) };
+	/**
+	 * 
+	 * @param  {number} svgX
+	 * @param  {number} svgY
+	 * @param  {Object} crs
+	 * @param  {Object} inv
+	 * @returns {Object} { lng: number, lat: number } 形式のオブジェクト または null
+	 */
 	SVG2Geo(...params){ return (this.#matUtil.SVG2Geo(...params)) };
 	addEvent( ){ return (UtilFuncs.addEvent) };
 	/**


### PR DESCRIPTION
# Changes
- 下記のメソッドについてJSDocによって引数と返り値を明確化した
  - `Geo2SVG`
  - `POIviewSelection`
  - `SVG2Geo`
# Issue
現状、SVGMapは高木さん以外の理解が追いついていないため、キャッチアップが難しい。  
そのため、各メソッドの可読性向上に取り組む必要がある。  